### PR TITLE
use the standard licence text with the current logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ tbd
 
 ## License
 
-<!-- https://chooser-beta.creativecommons.org/ -->
- <p xmlns:cc="http://creativecommons.org/ns#" >This work © 2021 by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://github.com/cagix">Carsten Gips</a> is licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-SA 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a></p>
+<!-- https://creativecommons.org/choose/ -->
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/cagix" property="cc:attributionName" rel="cc:attributionURL">Carsten Gips</a> is licensed under <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.


### PR DESCRIPTION
The licence is unchanged (remains CC BY-SA 4.0), but the text was created with the standard licence tool at https://creativecommons.org/choose/ this time, which uses the current logo. This one is rendered better in Github.
